### PR TITLE
Fix the ReadTheDocs build and update examples

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+python:
+   version: 3.7
+   install:
+      - method: pip
+        path: .
+        extra_requirements:
+           - docs

--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ We can then view the files associated with the project in the repository
 ``` Python
 >>> remote_files = proj.remote_files()
 >>> print(remote_files)
-# ['F063721.dat', 'F063721.dat-mztab.txt',
-# 'PRIDE_Exp_Complete_Ac_22134.xml.gz', 'PRIDE_Exp_mzData_Ac_22134.xml.gz',
-# 'PXD000001_mztab.txt', 'README.txt',
+# ['F063721.dat', 'F063721.dat-mztab.txt', 'PXD000001_mztab.txt',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML',
@@ -86,9 +84,9 @@ specific types of files:
 Then we can download one or more files to the projects local data directory:
 
 ``` Python
->>> downloaded = proj.download("README.txt")
+>>> downloaded = proj.download("F063721.dat-mztab.txt")
 >>> print(downloaded)
-# [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
+# [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
 ```
 
 Once we've downloaded files, ppx no longer needs an internet connection to
@@ -102,7 +100,7 @@ session, we can find our previous file easily:
 >>> proj = ppx.find_project("PXD000001", repo="PRIDE")
 >>> local_files = proj.local_files()
 >>> print(local_files)
-# [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
+# [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
 ```
 
 ## If you are an R user...

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,22 +43,22 @@ on PRIDE:
 
     >>> remote_files = proj.remote_files()
     >>> print(remote_files)
-    ['F063721.dat', 'F063721.dat-mztab.txt', 'PRIDE_Exp_Complete_Ac_22134.xml.gz', 'PRIDE_Exp_mzData_Ac_22134.xml.gz', 'PXD000001_mztab.txt', 'README.txt', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw', 'erwinia_carotovora.fasta']
+    ['F063721.dat', 'F063721.dat-mztab.txt', 'PXD000001_mztab.txt',  'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw', 'erwinia_carotovora.fasta']
 
 Alternatively, we can `glob
 <https://en.wikipedia.org/wiki/Glob_(programming)>`_ for specific files of
 interest:
 
-    >>> mzml_files = proje.remote_files("*.mzML")
+    >>> mzml_files = proj.remote_files("*.mzML")
     >>> print(mzml_files)
     ['TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML']
 
 Once we've determined what file we desire to download, we can download
 them to our local data directory. In this case, that is `~/.ppx/PXD000001`:
 
-    >>> downloaded = proj.download("README.txt")
+    >>> downloaded = proj.download("F063721.dat-mztab.txt")
     >>> print(downloaded)
-    [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
+    [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
 
 
 Once we've downloaded files, ppx no longer needs an internet connection to
@@ -70,8 +70,7 @@ session, we can find our previous files easily:
     >>> proj = ppx.find_project("PXD000001", rep="PRIDE")
     >>> local_files = proj.local_files()
     >>> print(local_files)
-    [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
+    [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
 
-For more details about the available methods for a project, see our Python API
-documentation for the :py:class:`~ppx.PrideProject` and
+For more details about the available methods for a project, see our Python API documentation for the :py:class:`~ppx.PrideProject` and
 :py:class:`~ppx.MassiveProject` classes.


### PR DESCRIPTION
The RTD build needed the optional install requirements.

Also, usage examples referenced a "README.txt" from PRIDE, but those are not listed by the PRIDE REST API.