### PR TITLE
Improve finding remote files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - The PRIDE REST API was not yielding all of the available files on the their
   FTP server for a project. We changed the backend use the FTP server directly
   instead. **Note that this may change the number, identity, and order of the
-  file that were previously returned for PRIDE projects**
+  file that were previously returned for PRIDE projects!**
 - Small documentation updates.
   
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog for ppx
 
+## [1.1.0] - 2021-05-18
+### Fixed
+- The PRIDE REST API was not yielding all of the available files on the their
+  FTP server for a project. We changed the backend use the FTP server directly
+  instead. **Note that this may change the number, identity, and order of the
+  file that were previously returned for PRIDE projects**
+- Small documentation updates.
+  
+### Added
+- Caching of the remote files and directories found for a project. If a 
+  project's `fetch` attribute is `False`, then we'll rely on this cached
+  data, so long as it is available. Setting `fetch=True` will always refresh
+  the data from the repository.
+
 ## [1.0.0] - 2021-05-14  
 ### Changed  
 - **We did a complete rework of the API!** This will break nearly all previous

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # A Python interface to proteomics data repositories
 
+[![conda](https://img.shields.io/conda/vn/bioconda/ppx?color=green)](http://bioconda.github.io/recipes/ppx/README.html)
+[![PyPI](https://img.shields.io/pypi/v/ppx?color=green)](https://pypi.org/project/ppx/)
 [![tests](https://github.com/wfondrie/ppx/workflows/tests/badge.svg?branch=master)](https://github.com/wfondrie/ppx/actions?query=workflow%3Atests)[![Documentation Status](https://readthedocs.org/projects/ppx/badge/?version=latest)](https://ppx.readthedocs.io/en/latest/?badge=latest)  
 
 ## Overview  

--- a/README.md
+++ b/README.md
@@ -18,9 +18,18 @@ For full documentation and examples, visit: https://ppx.readthedocs.io
 ppx requires Python 3.6+ and depends upon the
 [requests](https://docs.python-requests.org/en/master/) and
 [tqdm](https://tqdm.github.io/) Python packages. ppx and any missing
-dependencies are easily installed with `pip`:
+dependencies are easily installed with `pip` or with `conda` through the 
+[bioconda](https://bioconda.github.io/index.html) channel.
 
+Install with `conda`:
+
+``` shell
+conda install -c bioconda ppx
 ```
+
+Or install with `pip`:
+
+```shell
 pip3 install ppx
 ```
 
@@ -62,31 +71,35 @@ We can then view the files associated with the project in the repository
 (PRIDE in this case):
 
 ``` Python
->>> remote_files = proj.remote_files()
->>> print(remote_files)
-# ['F063721.dat', 'F063721.dat-mztab.txt', 'PXD000001_mztab.txt',
+>>> proj.remote_files()
+#['F063721.dat',
+# 'F063721.dat-mztab.txt',
+# 'PRIDE_Exp_Complete_Ac_22134.xml.gz',
+# 'PRIDE_Exp_mzData_Ac_22134.xml.gz',
+# 'PXD000001_mztab.txt',
+# 'README.txt',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML',
 # 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw',
-# 'erwinia_carotovora.fasta']
+# 'erwinia_carotovora.fasta',
+# 'generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz',
+# 'generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz']
 ```
 
 We can also [glob](https://en.wikipedia.org/wiki/Glob_(programming)) for
 specific types of files:
 
 ``` Python
->>> mzml_files = proj.remote_files("*.mzML")
->>> print(mzml_files)
+>>> proj.remote_files("*.mzML")
 # ['TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML']
 ```
 
 Then we can download one or more files to the projects local data directory:
 
 ``` Python
->>> downloaded = proj.download("F063721.dat-mztab.txt")
->>> print(downloaded)
-# [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
+>>> proj.download("README.txt")
+# [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
 ```
 
 Once we've downloaded files, ppx no longer needs an internet connection to
@@ -98,13 +111,12 @@ session, we can find our previous file easily:
 >>> import ppx
 
 >>> proj = ppx.find_project("PXD000001", repo="PRIDE")
->>> local_files = proj.local_files()
->>> print(local_files)
-# [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
+>>> proj.local_files()
+# [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
 ```
 
 ## If you are an R user...
 
-ppx was inpsired the rpx R package by Laurent Gatto. Check it out on
+ppx was inspired the rpx R package by Laurent Gatto. Check it out on
 [Bioconductor](http://bioconductor.org/packages/release/bioc/html/rpx.html) and
 [GitHub](https://github.com/lgatto/rpx).

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -31,6 +31,7 @@ html.writer-html4 .rst-content dl:not(.docutils)>dt,
 html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt {
     background: #C9F4ED;
     border-top: 3px solid #24B8A0;
+    color: #24B8A0;
 }
 
 /** [source] link **/
@@ -55,4 +56,3 @@ html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(
     color: #444444;
 }
 **/
-.rst-content dl:not(.docutils) dt:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,10 @@
+.. image:: https://img.shields.io/conda/vn/bioconda/ppx?color=green
+   :target: http://bioconda.github.io/recipes/ppx/README.html
+   :alt: bioconda
+
+.. image:: https://img.shields.io/pypi/v/ppx?color=green
+   :target: https://pypi.org/project/ppx/
+   :alt: PyPI
 
 .. image:: https://github.com/wfondrie/ppx/workflows/tests/badge.svg?branch=master
    :target: https://github.com/wfondrie/ppx/actions?query=workflow%3Atests
@@ -26,7 +33,13 @@ Installation
 ppx requires Python 3.6+ and depends upon the `requests
 <https://docs.python-requests.org/en/master/>`_ and `tqdm
 <https://tqdm.github.io/>`_ Python packages. ppx and any missing dependencies
-can be installed with :code:`pip`::
+can be installed with :code:`pip`: or :code:`conda`.
+
+Install with :code:`conda`:
+
+    conda install -c bioconda ppx
+
+Or install with :code:`pip`:
 
     pip install ppx
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,12 +38,13 @@ example, we'll use a project from PRIDE:
 
 Here, :code:`proj` is a is :py:class:`~ppx.PrideProject` object with
 methods that let us explore the available files and download files that we
-select. Let's retreive a list of all of the files associated with this project
+select. Let's retrieve a list of all of the files associated with this project
 on PRIDE:
 
     >>> remote_files = proj.remote_files()
     >>> print(remote_files)
-    ['F063721.dat', 'F063721.dat-mztab.txt', 'PXD000001_mztab.txt',  'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw', 'erwinia_carotovora.fasta']
+    ['F063721.dat', 'F063721.dat-mztab.txt', 'PRIDE_Exp_Complete_Ac_22134.xml.gz', 'PRIDE_Exp_mzData_Ac_22134.xml.gz', 'PXD000001_mztab.txt', 'README.txt', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML', 'TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw', 'erwinia_carotovora.fasta', 'generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz', 'generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz']
+
 
 Alternatively, we can `glob
 <https://en.wikipedia.org/wiki/Glob_(programming)>`_ for specific files of
@@ -72,5 +73,6 @@ session, we can find our previous files easily:
     >>> print(local_files)
     [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
 
-For more details about the available methods for a project, see our Python API documentation for the :py:class:`~ppx.PrideProject` and
+For more details about the available methods for a project, see our Python API
+documentation for the :py:class:`~ppx.PrideProject` and
 :py:class:`~ppx.MassiveProject` classes.

--- a/ppx/config.py
+++ b/ppx/config.py
@@ -56,7 +56,7 @@ def set_data_dir(path=None):
 
     Parameters
     ----------
-    path : str or Path object, optional
+    path : str or pathlib.Path object, optional
         The path for ppx to use as its data directory.
     """
     config.path = path

--- a/ppx/massive.py
+++ b/ppx/massive.py
@@ -17,7 +17,7 @@ class MassiveProject(BaseProject):
     ----------
     msv_id : str
         The MassIVE identifier.
-    local : str or path object, optional
+    local : str or pathlib.Path object, optional
         The local data directory in which to download project files.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?

--- a/ppx/massive.py
+++ b/ppx/massive.py
@@ -127,11 +127,15 @@ class MassiveProject(BaseProject):
         list of str
             The remote files available for this project.
         """
-        files = self._parser.files
-        if glob is not None:
-            files = [f for f in files if Path(f).match(glob)]
+        if self.fetch or self._remote_files is None:
+            self._remote_files = self._parser.files
 
-        return self._parser.files
+        if glob is not None:
+            files = [f for f in self._remote_files if Path(f).match(glob)]
+        else:
+            files = self._remote_files
+
+        return files
 
 
 def list_projects():

--- a/ppx/massive.py
+++ b/ppx/massive.py
@@ -37,8 +37,6 @@ class MassiveProject(BaseProject):
         """Instantiate a MSVDataset object"""
         super().__init__(msv_id, local, fetch)
         self._url = f"ftp://massive.ucsd.edu/{self.id}"
-        self._parser = FTPParser(self._url)
-        self._metadata = None
 
     def _validate_id(self, identifier):
         """Validate a MassIVE identifier.
@@ -92,50 +90,6 @@ class MassiveProject(BaseProject):
     def description(self):
         """A description of this project."""
         return self.metadata["dataset.comments"]
-
-    def remote_dirs(self, glob=None):
-        """List the project directories in the remote repository.
-
-        Parameters
-        ----------
-        glob : str, optional
-            Use Unix wildcards to return specific files. For example,
-            :code:`"*peak"` would return all directories ending in "peak".
-
-        Returns
-        -------
-        list of str
-            The remote directories available for this project.
-        """
-        dirs = self._parser.dirs
-        if glob is not None:
-            dirs = [d for d in dirs if Path(d).match(glob)]
-
-        return dirs
-
-    def remote_files(self, glob=None):
-        """List the project files in the remote repository.
-
-        Parameters
-        ----------
-        glob : str, optional
-            Use Unix wildcards to return specific files. For example,
-            :code:`"*.mzML"` would return all of the mzML files.
-
-        Returns
-        -------
-        list of str
-            The remote files available for this project.
-        """
-        if self.fetch or self._remote_files is None:
-            self._remote_files = self._parser.files
-
-        if glob is not None:
-            files = [f for f in self._remote_files if Path(f).match(glob)]
-        else:
-            files = self._remote_files
-
-        return files
 
 
 def list_projects():

--- a/ppx/pride.py
+++ b/ppx/pride.py
@@ -19,7 +19,7 @@ class PrideProject(BaseProject):
     ----------
     pride_id : str
         The PRIDE identifier.
-    local : str or Path-like object, optional
+    local : str or pathlib.Path object, optional
         The local data directory in which to download project files.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?

--- a/ppx/pride.py
+++ b/ppx/pride.py
@@ -45,7 +45,6 @@ class PrideProject(BaseProject):
         """Instantiate a PrideDataset object"""
         super().__init__(pride_id, local, fetch)
         self._url = self.rest + self.id
-        self._remote_files = None
         self._parser = None
         self._metadata = None
 
@@ -132,7 +131,7 @@ class PrideProject(BaseProject):
         list of str
             The remote files available for this project.
         """
-        if self._remote_files is None:
+        if self.fetch or self._remote_files is None:
             res = get(self.file_rest, params={"accession": self.id})
             self._remote_files = sorted(
                 [

--- a/tests/data/pride_files_response.json
+++ b/tests/data/pride_files_response.json
@@ -1,365 +1,346 @@
-{
-  "_embedded": {
-    "files": [
+[
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "5bda360133398f66021c8889e01dce921cb51300c7269e1f2b0f20368ab20af6",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000410",
+      "name": "Other type file URI",
+      "value": "OTHER"
+    },
+    "checksum": "c37fa5f5d0e2b52d0e9e4825a1006e446b2dfff7",
+    "publicFileLocations": [
       {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "34476b308bb9dab10edab047891e2ef5ded65f458ba5c24022cfab3e1f757e90",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000410",
-          "name": "Other type file URI",
-          "value": "OTHER"
-        },
-        "checksum": "631f5821d741ac9ef0de4f067eaf033b968af8e2",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/erwinia_carotovora.fasta"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/erwinia_carotovora.fasta"
-          }
-        ],
-        "fileSizeBytes": 1657668,
-        "fileName": "erwinia_carotovora.fasta",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/34476b308bb9dab10edab047891e2ef5ded65f458ba5c24022cfab3e1f757e90"
-          }
-        }
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz"
       },
       {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "ffdea08e7981243dbf92b1cc6076edc8f481ba3e6db0d1e0ad641c8faa544b90",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000404",
-          "name": "Associated raw file URI",
-          "value": "RAW"
-        },
-        "checksum": "5e050c8abc697891e2286271e062a8144518108a",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw"
-          }
-        ],
-        "fileSizeBytes": 220475548,
-        "fileName": "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/ffdea08e7981243dbf92b1cc6076edc8f481ba3e6db0d1e0ad641c8faa544b90"
-          }
-        }
-      },
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz"
+      }
+    ],
+    "fileSizeBytes": 497985,
+    "fileName": "PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
       {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "8ce43227bda837e3cad6c4fa1b11c4094291c48d76ca469c66e0a4e1efebd7e7",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000409",
-          "name": "Peak list file URI",
-          "value": "PEAK"
-        },
-        "checksum": "93bd2b2461acb02b5bcabbf7faa9ff0c471267f4",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML"
-          }
-        ],
-        "fileSizeBytes": 243031280,
-        "fileName": "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/8ce43227bda837e3cad6c4fa1b11c4094291c48d76ca469c66e0a4e1efebd7e7"
-          }
-        }
-      },
-      {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "146448a5a94636a2564a48082859cefac47c5e490fdc97b092a45c49c0a183ed",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:1002848",
-          "name": "Result file URI",
-          "value": "RESULT"
-        },
-        "checksum": "99b90224bacfea9e67ce3974bfdd8abc9e227ec6",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/PRIDE_Exp_Complete_Ac_22134.xml.gz"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/PRIDE_Exp_Complete_Ac_22134.xml.gz"
-          }
-        ],
-        "fileSizeBytes": 10677205,
-        "fileName": "PRIDE_Exp_Complete_Ac_22134.xml.gz",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/146448a5a94636a2564a48082859cefac47c5e490fdc97b092a45c49c0a183ed"
-          }
-        }
-      },
-      {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "5bda360133398f66021c8889e01dce921cb51300c7269e1f2b0f20368ab20af6",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000410",
-          "name": "Other type file URI",
-          "value": "OTHER"
-        },
-        "checksum": "c37fa5f5d0e2b52d0e9e4825a1006e446b2dfff7",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz"
-          }
-        ],
-        "fileSizeBytes": 497985,
-        "fileName": "PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/5bda360133398f66021c8889e01dce921cb51300c7269e1f2b0f20368ab20af6"
-          }
-        }
-      },
-      {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "ca2e3dea18950a328b7dc8303911961267a2c19058e67bfe49ab0d6784c3f62b",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000409",
-          "name": "Peak list file URI",
-          "value": "PEAK"
-        },
-        "checksum": "4bfcf84592a6cc6943ef3124427c524c4591d692",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz"
-          }
-        ],
-        "fileSizeBytes": 16448103,
-        "fileName": "PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/ca2e3dea18950a328b7dc8303911961267a2c19058e67bfe49ab0d6784c3f62b"
-          }
-        }
-      },
-      {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "8e9f031d8e56f5026860a1b116cbb8769787993c35f72b1d449254963c787b65",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000410",
-          "name": "Other type file URI",
-          "value": "OTHER"
-        },
-        "checksum": "e5037b5aefb15e75ca38bc4eed316df1c6ccbbfb",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/F063721.dat-mztab.txt"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/F063721.dat-mztab.txt"
-          }
-        ],
-        "fileSizeBytes": 304798,
-        "fileName": "F063721.dat-mztab.txt",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/8e9f031d8e56f5026860a1b116cbb8769787993c35f72b1d449254963c787b65"
-          }
-        }
-      },
-      {
-        "projectAccessions": [
-          "PXD000001"
-        ],
-        "accession": "4b46ae91064697f1c8df768df676ffaf7c6f0dad4f29523003be62fa09e7826c",
-        "fileCategory": {
-          "@type": "CvParam",
-          "cvLabel": "PRIDE",
-          "accession": "PRIDE:0000408",
-          "name": "Search engine output file URI",
-          "value": "SEARCH"
-        },
-        "checksum": "54fac65e53d61c56f5f46e9b4347d722a57cdc2e",
-        "publicFileLocations": [
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000469",
-            "name": "FTP Protocol",
-            "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/F063721.dat"
-          },
-          {
-            "@type": "CvParam",
-            "cvLabel": "PRIDE",
-            "accession": "PRIDE:0000468",
-            "name": "Aspera Protocol",
-            "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/F063721.dat"
-          }
-        ],
-        "fileSizeBytes": 21185462,
-        "fileName": "F063721.dat",
-        "compress": false,
-        "submissionDate": "2012-03-13T00:00:00.000+0000",
-        "publicationDate": "2012-03-07T00:00:00.000+0000",
-        "updatedDate": "2017-06-20T14:57:06.000+0000",
-        "additionalAttributes": [],
-        "_links": {
-          "self": {
-            "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/4b46ae91064697f1c8df768df676ffaf7c6f0dad4f29523003be62fa09e7826c"
-          }
-        }
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/5bda360133398f66021c8889e01dce921cb51300c7269e1f2b0f20368ab20af6"
       }
     ]
   },
-  "_links": {
-    "self": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files?filter=''&pageSize=100&page=0&sortDirection=DESC&sortConditions=fileName"
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "ca2e3dea18950a328b7dc8303911961267a2c19058e67bfe49ab0d6784c3f62b",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000409",
+      "name": "Peak list file URI",
+      "value": "PEAK"
     },
-    "next": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files?filter=''&pageSize=100&page=1&sortDirection=DESC&sortConditions=fileName"
-    },
-    "previous": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files?filter=''&pageSize=100&page=0&sortDirection=DESC&sortConditions=fileName"
-    },
-    "first": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files?filter=''&pageSize=100&page=0&sortDirection=DESC&sortConditions=fileName"
-    },
-    "last": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files?filter=''&pageSize=100&page=1&sortDirection=DESC&sortConditions=fileName"
-    }
+    "checksum": "4bfcf84592a6cc6943ef3124427c524c4591d692",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz"
+      }
+    ],
+    "fileSizeBytes": 16448103,
+    "fileName": "PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/ca2e3dea18950a328b7dc8303911961267a2c19058e67bfe49ab0d6784c3f62b"
+      }
+    ]
   },
-  "page": {
-    "size": 100,
-    "totalElements": 8,
-    "totalPages": 1,
-    "number": 0
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "8ce43227bda837e3cad6c4fa1b11c4094291c48d76ca469c66e0a4e1efebd7e7",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000409",
+      "name": "Peak list file URI",
+      "value": "PEAK"
+    },
+    "checksum": "93bd2b2461acb02b5bcabbf7faa9ff0c471267f4",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML"
+      }
+    ],
+    "fileSizeBytes": 243031280,
+    "fileName": "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/8ce43227bda837e3cad6c4fa1b11c4094291c48d76ca469c66e0a4e1efebd7e7"
+      }
+    ]
+  },
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "34476b308bb9dab10edab047891e2ef5ded65f458ba5c24022cfab3e1f757e90",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000410",
+      "name": "Other type file URI",
+      "value": "OTHER"
+    },
+    "checksum": "631f5821d741ac9ef0de4f067eaf033b968af8e2",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/erwinia_carotovora.fasta"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/erwinia_carotovora.fasta"
+      }
+    ],
+    "fileSizeBytes": 1657668,
+    "fileName": "erwinia_carotovora.fasta",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/34476b308bb9dab10edab047891e2ef5ded65f458ba5c24022cfab3e1f757e90"
+      }
+    ]
+  },
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "ffdea08e7981243dbf92b1cc6076edc8f481ba3e6db0d1e0ad641c8faa544b90",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000404",
+      "name": "Associated raw file URI",
+      "value": "RAW"
+    },
+    "checksum": "5e050c8abc697891e2286271e062a8144518108a",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw"
+      }
+    ],
+    "fileSizeBytes": 220475548,
+    "fileName": "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/ffdea08e7981243dbf92b1cc6076edc8f481ba3e6db0d1e0ad641c8faa544b90"
+      }
+    ]
+  },
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "8e9f031d8e56f5026860a1b116cbb8769787993c35f72b1d449254963c787b65",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000410",
+      "name": "Other type file URI",
+      "value": "OTHER"
+    },
+    "checksum": "e5037b5aefb15e75ca38bc4eed316df1c6ccbbfb",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/F063721.dat-mztab.txt"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/F063721.dat-mztab.txt"
+      }
+    ],
+    "fileSizeBytes": 304798,
+    "fileName": "F063721.dat-mztab.txt",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/8e9f031d8e56f5026860a1b116cbb8769787993c35f72b1d449254963c787b65"
+      }
+    ]
+  },
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "146448a5a94636a2564a48082859cefac47c5e490fdc97b092a45c49c0a183ed",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:1002848",
+      "name": "Result file URI",
+      "value": "RESULT"
+    },
+    "checksum": "99b90224bacfea9e67ce3974bfdd8abc9e227ec6",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/PRIDE_Exp_Complete_Ac_22134.xml.gz"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/PRIDE_Exp_Complete_Ac_22134.xml.gz"
+      }
+    ],
+    "fileSizeBytes": 10677205,
+    "fileName": "PRIDE_Exp_Complete_Ac_22134.xml.gz",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/146448a5a94636a2564a48082859cefac47c5e490fdc97b092a45c49c0a183ed"
+      }
+    ]
+  },
+  {
+    "projectAccessions": [
+      "PXD000001"
+    ],
+    "accession": "4b46ae91064697f1c8df768df676ffaf7c6f0dad4f29523003be62fa09e7826c",
+    "fileCategory": {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000408",
+      "name": "Search engine output file URI",
+      "value": "SEARCH"
+    },
+    "checksum": "54fac65e53d61c56f5f46e9b4347d722a57cdc2e",
+    "publicFileLocations": [
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000469",
+        "name": "FTP Protocol",
+        "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/F063721.dat"
+      },
+      {
+        "@type": "CvParam",
+        "cvLabel": "PRIDE",
+        "accession": "PRIDE:0000468",
+        "name": "Aspera Protocol",
+        "value": "prd_ascp@fasp.ebi.ac.uk:pride/data/archive/2012/03/PXD000001/F063721.dat"
+      }
+    ],
+    "fileSizeBytes": 21185462,
+    "fileName": "F063721.dat",
+    "compress": false,
+    "submissionDate": 1331596800000,
+    "publicationDate": 1331078400000,
+    "updatedDate": 1497970626000,
+    "additionalAttributes": [],
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/4b46ae91064697f1c8df768df676ffaf7c6f0dad4f29523003be62fa09e7826c"
+      }
+    ]
   }
-}
+]

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -21,7 +21,7 @@ def test_pride_download(tmp_path):
     files = proj.local_files()
     local_txt = tmp_path / PXID / fname
     assert txt == [local_txt]
-    assert files[1] == local_txt
+    assert files[0] == local_txt
 
 
 def test_massive_download(tmp_path):

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -131,6 +131,13 @@ def test_remote_files(mock_pride_project_response):
     assert proj.remote_files("blah") == []
 
 
+def test_remote_files(mock_pride_project_response):
+    """Test that listing remote directories works"""
+    proj = ppx.PrideProject(PXID)
+    dirs = proj.remote_dirs()
+    assert dirs == ["generated"]
+
+
 def test_cached_remote_files(tmp_path, mock_pride_project_response):
     """Test that caching remote files works"""
     cached = tmp_path / ".remote_files"
@@ -146,6 +153,23 @@ def test_cached_remote_files(tmp_path, mock_pride_project_response):
     proj.fetch = True
     files = proj.remote_files()
     assert files != test_files
+
+
+def test_cached_remote_dirs(tmp_path, mock_pride_project_response):
+    """Test that caching remote directories works"""
+    cached = tmp_path / ".remote_dirs"
+
+    test_dirs = ["test1", "test2"]
+    with cached.open("w+") as ref:
+        ref.write("\n".join(test_dirs))
+
+    proj = ppx.PrideProject(PXID, local=tmp_path)
+    files = proj.remote_dirs()
+    assert files == test_dirs
+
+    proj.fetch = True
+    files = proj.remote_dirs()
+    assert files != test_dirs
 
 
 def test_local_files(local_files, tmp_path):

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -123,6 +123,23 @@ def test_remote_files(mock_pride_files_response):
     assert proj.remote_files("blah") == []
 
 
+def test_cached_remote_files(tmp_path, mock_pride_files_response):
+    """Test that caching remote files works"""
+    cached = tmp_path / ".remote_files"
+
+    test_files = ["test1", "test2"]
+    with cached.open("w+") as ref:
+        ref.write("\n".join(test_files))
+
+    proj = ppx.PrideProject(PXID, local=tmp_path)
+    files = proj.remote_files()
+    assert files == test_files
+
+    proj.fetch = True
+    files = proj.remote_files()
+    assert files != test_files
+
+
 def test_local_files(local_files, tmp_path):
     """Test that finding local files works"""
     proj = ppx.PrideProject(PXID, local=tmp_path)

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -11,7 +11,7 @@ PXID = "PXD000001"
 def test_init(tmp_path):
     """Test initialization"""
     proj = ppx.PrideProject(PXID)
-    url = "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001"
+    url = "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001"
     assert proj.id == PXID
     assert proj.url == url
     assert proj.local == tmp_path / "PXD000001"
@@ -88,7 +88,7 @@ def test_metadata(mock_pride_project_response):
     assert proj.doi == "10.6019/PXD000001"
 
 
-def test_remote_files(mock_pride_files_response):
+def test_remote_files(mock_pride_project_response):
     """Test that listing remote files works"""
     proj = ppx.PrideProject(PXID)
     files = proj.remote_files()
@@ -96,6 +96,11 @@ def test_remote_files(mock_pride_files_response):
         "F063721.dat",
         "F063721.dat-mztab.txt",
         "PRIDE_Exp_Complete_Ac_22134.xml.gz",
+        "PRIDE_Exp_mzData_Ac_22134.xml.gz",
+        "PXD000001_mztab.txt",
+        "README.txt",
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML",
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML",
         "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
         "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
         "erwinia_carotovora.fasta",
@@ -109,6 +114,7 @@ def test_remote_files(mock_pride_files_response):
     print(gzipped)
     true_gzipped = [
         "PRIDE_Exp_Complete_Ac_22134.xml.gz",
+        "PRIDE_Exp_mzData_Ac_22134.xml.gz",
         "generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
         "generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
     ]
@@ -116,6 +122,8 @@ def test_remote_files(mock_pride_files_response):
 
     ms_files = proj.remote_files("*60min_01*")
     true_ms_files = [
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML",
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML",
         "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
         "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
     ]
@@ -123,7 +131,7 @@ def test_remote_files(mock_pride_files_response):
     assert proj.remote_files("blah") == []
 
 
-def test_cached_remote_files(tmp_path, mock_pride_files_response):
+def test_cached_remote_files(tmp_path, mock_pride_project_response):
     """Test that caching remote files works"""
     cached = tmp_path / ".remote_files"
 

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -93,29 +93,31 @@ def test_remote_files(mock_pride_files_response):
     proj = ppx.PrideProject(PXID)
     files = proj.remote_files()
     true_files = [
-        "erwinia_carotovora.fasta",
-        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
-        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
-        "PRIDE_Exp_Complete_Ac_22134.xml.gz",
-        "PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
-        "PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
-        "F063721.dat-mztab.txt",
         "F063721.dat",
+        "F063721.dat-mztab.txt",
+        "PRIDE_Exp_Complete_Ac_22134.xml.gz",
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
+        "erwinia_carotovora.fasta",
+        "generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
+        "generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
     ]
+
     assert files == true_files
 
     gzipped = proj.remote_files("*.gz")
+    print(gzipped)
     true_gzipped = [
         "PRIDE_Exp_Complete_Ac_22134.xml.gz",
-        "PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
-        "PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
+        "generated/PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
+        "generated/PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
     ]
     assert gzipped == true_gzipped
 
     ms_files = proj.remote_files("*60min_01*")
     true_ms_files = [
-        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
         "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
+        "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
     ]
     assert ms_files == true_ms_files
     assert proj.remote_files("blah") == []


### PR DESCRIPTION
I noticed that some files on PRIDE were not found using the REST API call that ppx was using. It turns out that the `projects/files` API endpoint is not equivalent to the `files/byAccession` API endpoint. This PR switches to the latter. 

Additionally, I've added a caching mechanism for the remote file names. This should speed up ppx and result in fewer API calls overall.