### PR TITLE
Make the FTP connections more robust

### DIFF
--- a/ppx/project.py
+++ b/ppx/project.py
@@ -193,7 +193,7 @@ class BaseProject(ABC):
         files = self.local.glob(glob)
         return sorted([f for f in files if f.is_file()])
 
-    def download(self, files, silent=False):
+    def download(self, files, force_=False, silent=False):
         """Download files from the remote repository.
 
         These files are downloaded to this project's local data directory
@@ -205,6 +205,8 @@ class BaseProject(ABC):
         ----------
         files : str or list of str
             One or more files to be downloaded from the remote repository.
+        force_ : bool, optional
+            Force the files to be downloaded, even if they already exist.
         silent : bool, optional
             Hide download progress bars?
 
@@ -224,7 +226,9 @@ class BaseProject(ABC):
                 f"{', '.join(missing)}"
             )
 
-        return self._parser.download(files, self.local, silent=silent)
+        return self._parser.download(
+            files, self.local, force_=force_, silent=silent
+        )
 
 
 def cache(files, cache_file, fetch):

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -193,7 +193,7 @@ class BaseProject(ABC):
         files = self.local.glob(glob)
         return sorted([f for f in files if f.is_file()])
 
-    def download(self, files, force_=False, silent=False):
+    def download(self, files, silent=False):
         """Download files from the remote repository.
 
         These files are downloaded to this project's local data directory
@@ -205,9 +205,6 @@ class BaseProject(ABC):
         ----------
         files : str or list of str
             One or more files to be downloaded from the remote repository.
-        force_ : bool, optional
-            Redownload files when files of the of the same name already appear
-            in the local data directory?
         silent : bool, optional
             Hide download progress bars?
 
@@ -227,9 +224,7 @@ class BaseProject(ABC):
                 f"{', '.join(missing)}"
             )
 
-        return self._parser.download(
-            files, self.local, force_=force_, silent=silent
-        )
+        return self._parser.download(files, self.local, silent=silent)
 
 
 def cache(files, cache_file, fetch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,6 @@ def block_internet(monkeypatch):
 
     class Blocker(socket.socket):
         def __init__(self, *args, **kwargs):
-            raise Exception("Network call blocked")
+            raise OSError("Network call blocked")
 
     monkeypatch.setattr(socket, "socket", Blocker)

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -2,6 +2,8 @@
 
 These tests are in a separate file because they all require internet access.
 """
+import filecmp
+
 import pytest
 import ppx
 
@@ -20,15 +22,17 @@ def test_pride_download(tmp_path):
     txt = proj.download(fname)
     files = proj.local_files()
     local_txt = tmp_path / PXID / fname
-    orig_stat = local_txt.stat()
+    orig_sig = sig(local_txt)
     assert txt == [local_txt]
     assert files[0] == local_txt
 
     txt = proj.download(fname)  # should do nothing
-    assert orig_stat == local_txt.stat()
+    assert orig_sig == sig(local_txt)
 
     txt = proj.download(fname, force_=True)
-    assert orig_stat != local_txt.stat()
+    new_size, new_mtime = sig(local_txt)
+    assert orig_sig[0] == new_size
+    assert orig_sig[1] != new_mtime
 
 
 def test_massive_download(tmp_path):
@@ -41,12 +45,19 @@ def test_massive_download(tmp_path):
     txt = proj.download(fname)
     files = proj.local_files()
     local_txt = tmp_path / MSVID / fname
-    orig_stat = local_txt.stat()
+    orig_sig = sig(local_txt)
     assert txt == [local_txt]
     assert files[0] == local_txt
 
     txt = proj.download(fname)  # should do nothing
-    assert orig_stat == local_txt.stat()
+    assert orig_sig == sig(local_txt)
 
     txt = proj.download(fname, force_=True)
-    assert orig_stat != local_txt.stat()
+    new_size, new_mtime = sig(local_txt)
+    assert orig_sig[0] == new_size
+    assert orig_sig[1] != new_mtime
+
+
+def sig(f):
+    st = f.stat()
+    return st.st_size, st.st_mtime

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -20,8 +20,15 @@ def test_pride_download(tmp_path):
     txt = proj.download(fname)
     files = proj.local_files()
     local_txt = tmp_path / PXID / fname
+    orig_stat = local_txt.stat()
     assert txt == [local_txt]
     assert files[0] == local_txt
+
+    txt = proj.download(fname)  # should do nothing
+    assert orig_stat == local_txt.stat()
+
+    txt = proj.download(fname, force_=True)
+    assert orig_stat != local_txt.stat()
 
 
 def test_massive_download(tmp_path):
@@ -34,5 +41,12 @@ def test_massive_download(tmp_path):
     txt = proj.download(fname)
     files = proj.local_files()
     local_txt = tmp_path / MSVID / fname
+    orig_stat = local_txt.stat()
     assert txt == [local_txt]
     assert files[0] == local_txt
+
+    txt = proj.download(fname)  # should do nothing
+    assert orig_stat == local_txt.stat()
+
+    txt = proj.download(fname, force_=True)
+    assert orig_stat != local_txt.stat()

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -6,12 +6,26 @@ import filecmp
 
 import pytest
 import ppx
+from ftplib import FTP, error_temp
 
 PXID = "PXD000001"
 MSVID = "MSV000087408"
 
 
-# @pytest.mark.skip(reason="Seem to have problems with PRIDE connections :/")
+def test_no_internet(monkeypatch):
+    """Test what happens when connection is blocked"""
+    proj = ppx.PrideProject(PXID)
+    remote_files = proj.remote_files()
+    fname = "F063721.dat-mztab.txt"
+
+    def retrbinary(*args, **kwargs):
+        raise OSError("Mock error")
+
+    monkeypatch.setattr(FTP, "retrbinary", retrbinary)
+    with pytest.raises(error_temp):
+        txt = proj.download(fname)
+
+
 def test_pride_download(tmp_path):
     """Test downloading data from PRIDE"""
     proj = ppx.PrideProject(PXID)


### PR DESCRIPTION
Currently the FTP connections made by ppx are fragile: they don't attempt any reconnects if the connection is dropped. 

This can be annoying, making the tests randomly fail even on great networking setups. More importantly, it is annoying to have to try downloading the same file multiple times due to a poor internet connection.

This PR adds reconnects to file downloading to make it more robust. Additionally, when a file is requested for download, ppx will check the size of the local file against its size in the repository. If the local file is smaller, ppx assumes that a previous download was interrupted and starts downloading from the latest point.

TODO:
- [x] Add the logic for the `force_` parameter
- [x] Check the benefit of adding similar reconnects to the other FTP commands ppx uses.