### PR TITLE
Add timeout argument to project classes and find_project()

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Check for debugging print statements
         run: |
-          if grep -rq "print(" mokapot; then
+          if grep -rq "print(" ppx; then
               echo "Found the following print statements:"
-              grep -r "print(" mokapot
+              grep -r "print(" ppx
               exit 1
           fi

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -1,9 +1,8 @@
 """General utilities for working with the repository FTP sites."""
 import re
-import time
 import logging
 import socket
-from ftplib import FTP, error_temp, error_perm
+from ftplib import FTP, error_temp
 from pathlib import Path
 from functools import partial
 
@@ -59,7 +58,6 @@ class FTPParser:
             raise ValueError("The URL does not appear to be an FTP server")
 
         self.server, self.path = url.replace("ftp://", "").split("/", 1)
-        print(self.path)
         self.connection = None
         self.max_depth = max_depth
         self.max_reconnects = max_reconnects

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -97,6 +97,7 @@ class FTPParser:
 
             except (
                 ConnectionRefusedError,
+                ConnectionResetError,
                 socket.timeout,
                 socket.gaierror,
                 socket.herror,

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -46,9 +46,13 @@ class FTPParser:
         The url for the FTP connection.
     max_depth : int, optional
         The maximum resursion depth when looking for files.
+    max_reconnects : int, optional
+        The maximum number of reconnects to attempt during downloads.
+    timeout : float, optional
+        The maximum amount of time to wait for a response from the server.
     """
 
-    def __init__(self, url, max_depth=4, max_reconnects=10):
+    def __init__(self, url, max_depth=4, max_reconnects=10, timeout=10.0):
         """Initialize an FTPParser"""
         if not url.startswith("ftp://"):
             raise ValueError("The URL does not appear to be an FTP server")
@@ -57,6 +61,7 @@ class FTPParser:
         self.connection = None
         self.max_depth = max_depth
         self.max_reconnects = max_reconnects
+        self.timeout = timeout
         self._files = None
         self._dirs = None
         self._depth = 0
@@ -71,7 +76,7 @@ class FTPParser:
             self.connection = None
 
         if self.connection is None:
-            self.connection = FTP()
+            self.connection = FTP(timeout=self.timeout)
             self.connection.connect(self.server)
             self.connection.login()
             self.connection.cwd(self.path)

--- a/ppx/massive.py
+++ b/ppx/massive.py
@@ -21,6 +21,8 @@ class MassiveProject(BaseProject):
         The local data directory in which to download project files.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
+    timeout : float, optional
+        The maximum amount of time to wait for a server response.
 
     Attributes
     ----------
@@ -31,11 +33,12 @@ class MassiveProject(BaseProject):
     description : str
     metadata : dict
     fetch : bool
+    timeout : float
     """
 
-    def __init__(self, msv_id, local=None, fetch=False):
+    def __init__(self, msv_id, local=None, fetch=False, timeout=10.0):
         """Instantiate a MSVDataset object"""
-        super().__init__(msv_id, local, fetch)
+        super().__init__(msv_id, local, fetch, timeout)
         self._url = f"ftp://massive.ucsd.edu/{self.id}"
 
     def _validate_id(self, identifier):

--- a/ppx/pride.py
+++ b/ppx/pride.py
@@ -23,6 +23,8 @@ class PrideProject(BaseProject):
         The local data directory in which to download project files.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
+    timeout : float, optional
+        The maximum amount of time to wait for a server response.
 
     Attributes
     ----------
@@ -36,14 +38,15 @@ class PrideProject(BaseProject):
     sample_processing_protocol : str
     metadata : dict
     fetch : bool
+    timeout : float
     """
 
     rest = "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/"
     file_rest = "https://www.ebi.ac.uk/pride/ws/archive/v2/files/byProject"
 
-    def __init__(self, pride_id, local=None, fetch=False):
+    def __init__(self, pride_id, local=None, fetch=False, timeout=10.0):
         """Instantiate a PrideDataset object"""
-        super().__init__(pride_id, local, fetch)
+        super().__init__(pride_id, local, fetch, timeout)
         self._rest_url = self.rest + self.id
 
     def _validate_id(self, identifier):

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -19,13 +19,16 @@ class BaseProject(ABC):
         downloaded.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
+    timeout : float, optional
+        The maximum amount of time to wait for a server response.
     """
 
-    def __init__(self, identifier, local=None, fetch=False):
+    def __init__(self, identifier, local=None, fetch=False, timeout=10.0):
         """Initialize a BaseDataset"""
         self._id = self._validate_id(identifier)
         self.local = local
         self.fetch = fetch
+        self.timeout = timeout
         self._url = None
         self._parser_state = None
         self._metadata = None
@@ -33,10 +36,21 @@ class BaseProject(ABC):
         self._remote_dirs = None
 
     @property
+    def timeout(self):
+        """The maximum amount of time to wait for a server response."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, wait):
+        """Set the timeout for requests"""
+        self._timeout = wait
+        self._parser_state = None  # Reset the connection for new timeout.
+
+    @property
     def _parser(self):
         """The FTPParser"""
         if self._parser_state is None:
-            self._parser_state = FTPParser(self.url)
+            self._parser_state = FTPParser(self.url, timeout=self._timeout)
 
         return self._parser_state
 

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -6,7 +6,7 @@ import filecmp
 
 import pytest
 import ppx
-from ftplib import FTP, error_temp
+from ftplib import FTP, error_temp, error_perm
 
 PXID = "PXD000001"
 MSVID = "MSV000087408"
@@ -48,6 +48,9 @@ def test_pride_download(tmp_path):
     assert orig_sig[0] == new_size
     assert orig_sig[1] != new_mtime
 
+    proj.timeout = 10
+    assert proj._parser_state is None
+
 
 def test_massive_download(tmp_path):
     """Test downloading data from massive"""
@@ -70,6 +73,9 @@ def test_massive_download(tmp_path):
     new_size, new_mtime = sig(local_txt)
     assert orig_sig[0] == new_size
     assert orig_sig[1] != new_mtime
+
+    proj.timeout = 10
+    assert proj._parser_state is None
 
 
 def sig(f):

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -14,7 +14,7 @@ MSVID = "MSV000087408"
 
 def test_no_internet(monkeypatch):
     """Test what happens when connection is blocked"""
-    proj = ppx.PrideProject(PXID)
+    proj = ppx.PrideProject(PXID, timeout=None)
     remote_files = proj.remote_files()
     fname = "F063721.dat-mztab.txt"
 

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -6,7 +6,7 @@ import filecmp
 
 import pytest
 import ppx
-from ftplib import FTP, error_temp, error_perm
+from ftplib import FTP, error_temp
 
 PXID = "PXD000001"
 MSVID = "MSV000087408"

--- a/tests/unit_tests/test_find_project.py
+++ b/tests/unit_tests/test_find_project.py
@@ -2,6 +2,8 @@
 import pytest
 import ppx
 
+from requests.exceptions import ConnectTimeout
+
 PXID = "PXD000001"
 MSVID = "MSV000087408"
 MSVPXD = "PXD025981"
@@ -56,3 +58,9 @@ def test_massive_project_with_pxd():
     proj = ppx.find_project(MSVPXD)
     assert isinstance(proj, ppx.MassiveProject)
     assert proj.id == MSVID
+
+
+def test_timeout():
+    """Try a value that is too small."""
+    with pytest.raises(ConnectTimeout):
+        proj = ppx.find_project(PXID, timeout=0.0000000000001)

--- a/tests/unit_tests/test_massive.py
+++ b/tests/unit_tests/test_massive.py
@@ -32,6 +32,12 @@ def test_init(tmp_path):
     proj = ppx.MassiveProject(MSVID, fetch=True)
     assert proj.fetch
 
+    proj = ppx.MassiveProject(MSVID, timeout=2)
+    assert proj.timeout == 2
+
+    proj.timeout = 10
+    assert proj.timeout == 10
+
 
 def test_env(monkeypatch, tmp_path):
     """Test that the environment variable is respected"""

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -32,6 +32,12 @@ def test_init(tmp_path):
     proj = ppx.PrideProject(PXID, fetch=True)
     assert proj.fetch
 
+    proj = ppx.PrideProject(PXID, timeout=5)
+    assert proj.timeout == 5
+
+    proj.timeout = 10
+    assert proj.timeout == 10
+
 
 def test_env(monkeypatch, tmp_path):
     """Test that the environment variable works"""


### PR DESCRIPTION
This PR addresses Issue #11. The default is currently set to 10s. This seems high, but sometimes responses from PRIDE are slow and need >1s.

Additionally, this PR adds retry attempts to changing FTP directories, hopefully resolving Issue #12.