### PR TITLE
Lower requests version for google colab

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    requests>=2.25.1
+    requests>=2.23.0
     tqdm>=4.60.0
 
 [options.extras_require]


### PR DESCRIPTION
Trying to install on Google colab results in:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
google-colab 1.0.0 requires requests~=2.23.0, but you have requests 2.26.0 which is incompatible.
datascience 0.10.6 requires folium==0.2.1, but you have folium 0.8.3 which is incompatible.
```

This PR lowers the required version of the requests package, which shouldn't cause any issues.