### PR TITLE
Improve progress bars for notebook environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog for ppx
+
+## [Unreleased]
+### Changed
+- ppx progress bars now work much better in Jupyter environments. Under the
+  hood we switched from `from tqdm import tqdm` to `from tqdm.auto import
+  tqdm`.
+
 ## [1.2.2] - 2021-10-12
 ### Changed
 - Lowered the Requests version requirement to 2.23.0. This resolves a problem

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from functools import partial
 from ftplib import FTP, error_temp, error_perm
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from .utils import listify
 


### PR DESCRIPTION
The progress bars didn't really work well in Jupyter notebook environments. This PR fixes this problem by simply changing `from tqdm import tqdm` to `from tqdm.auto import tqdm`.