### PR TITLE
Hotfix to resolve PRIDE FTP URL change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog for ppx
 
-## [Unreleased]
+## [1.2.3] - 2021-11-05
+### Fixed
+- Hotfix for PRIDE's recent FTP URL change (see #18 for details).
+
 ### Changed
 - ppx progress bars now work much better in Jupyter environments. Under the
   hood we switched from `from tqdm import tqdm` to `from tqdm.auto import

--- a/ppx/pride.py
+++ b/ppx/pride.py
@@ -74,6 +74,13 @@ class PrideProject(BaseProject):
         if self._url is None:
             self._url = self.metadata["_links"]["datasetFtpUrl"]["href"]
 
+            # Hotfix for the latest PRIDE FTP change. See issue #18.
+            # Hopefully we can delete this once the REST API is updated.
+            self._url = self._url.replace(
+                "pride/data/archive",
+                "pride-archive",
+            )
+
         return self._url
 
     @property

--- a/tests/data/pride_project_response.json
+++ b/tests/data/pride_project_response.json
@@ -114,7 +114,7 @@
       "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files"
     },
     "datasetFtpUrl": {
-      "href": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001"
+      "href": "ftp://ftp.pride.ebi.ac.uk/pride-archive/2012/03/PXD000001"
     }
   }
 }

--- a/tests/unit_tests/test_find_project.py
+++ b/tests/unit_tests/test_find_project.py
@@ -2,7 +2,7 @@
 import pytest
 import ppx
 
-from requests.exceptions import ConnectTimeout
+from requests.exceptions import ConnectTimeout, ReadTimeout
 
 PXID = "PXD000001"
 MSVID = "MSV000087408"
@@ -44,23 +44,23 @@ def test_massive_offline(block_internet, tmp_path):
 # The following require internet access! --------------------------------------
 def test_pride_online():
     """Test pride project resolution"""
-    proj = ppx.find_project(PXID)
+    proj = ppx.find_project(PXID, timeout=10)
     assert isinstance(proj, ppx.PrideProject)
 
 
 def test_massive_project():
     """Test massive project resolution"""
-    proj = ppx.find_project(MSVID)
+    proj = ppx.find_project(MSVID, timeout=10)
     assert isinstance(proj, ppx.MassiveProject)
 
 
 def test_massive_project_with_pxd():
-    proj = ppx.find_project(MSVPXD)
+    proj = ppx.find_project(MSVPXD, timeout=10)
     assert isinstance(proj, ppx.MassiveProject)
     assert proj.id == MSVID
 
 
 def test_timeout():
     """Try a value that is too small."""
-    with pytest.raises(ConnectTimeout):
+    with pytest.raises((ConnectTimeout, ReadTimeout)):
         proj = ppx.find_project(PXID, timeout=0.0000000000001)

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -11,7 +11,7 @@ PXID = "PXD000001"
 def test_init(tmp_path):
     """Test initialization"""
     proj = ppx.PrideProject(PXID)
-    url = "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001"
+    url = "ftp://ftp.pride.ebi.ac.uk/pride-archive/2012/03/PXD000001"
     assert proj.id == PXID
     assert proj.url == url
     assert proj.local == tmp_path / "PXD000001"


### PR DESCRIPTION
This patch provides a fix for PRIDE's recent URL change. Resolves #18.