### PR TITLE
Add support for cloud storage backends

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.5b1 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for ppx
 
+## [1.3.0] - 2022-04-39
+### Added
+- Support for cloud provider destinations. Thanks @sooheon! 
+
 ## [1.2.6] - 2022-03-16
 ### Fixed
 - Some PRIDE projects were still not working due to their recent URL change.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Why does ppx set a default data directory? We found that this makes it easier
 to reuse the same proteomics data files in multiple tasks that we're working
 on.
 
+As of ppx v1.3.0, cloud paths can also be used as the data directory. This
+allows you to stream downloaded files to AWS S3, Google Cloud Storage, or Azure
+Blob Storage. To use a cloud storage provider, simply set the data directory to
+a cloud URI, such as :code:`s3://my-data-bucket/ppx` using any of the methods
+above. Please note that you'll also need to setup credentials for your cloud
+provider---see the `CloudPathLib documentation
+<https://cloudpathlib.drivendata.org/v0.6/authentication/>_` for details.
 
 ## Examples
 First, find a project using its ProteomeXchange or MassIVE identifier:
@@ -119,15 +126,25 @@ session, we can find our previous file easily:
 
 ### Downloading to cloud storage backend
 
-Uses [CloudPathlib](https://cloudpathlib.drivendata.org/stable/) backend.
+We use [CloudPathlib](https://cloudpathlib.drivendata.org/stable/) to power
+support for AWS S3, Google Cloud Storage, and Azure Blob Storage. To use a
+cloud storage provider, create the bucket for ppx to use and set it as the ppx data
+directory.
 
-You should create the storage bucket beforehand, to avoid bucket name conflict issues.
-If you're using GCP storage:
+
+For example using AWS S3, we can save the files of a project to an S3 bucket:
+``` python
+>>> proj = ppx.find_project("PXD000001", local="s3://my-bucket/PXD000001")
+>>> proj.download("README.txt")
+# [S3Path('s3://my-bucket/PXD000001/README.txt')]
+```
+
+CloudPathLib then provides methods to download files from S3 when you need them:
 
 ``` Python
->>> proj = ppx.find_project("PXD000001", local="gs://$YOUR_BUCKET")
->>> proj.download("README.txt")
-# [GSPath('gs://$YOUR_BUCKET/PXD000001/README.txt')]
+>>> readme_on_s3 = proj.local_files("README.txt")[0]
+>>> readme_on_s3.download_to("README.txt")
+# [PosixPath(README.txt)]
 ```
 
 ## If you are an R user...

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ session, we can find our previous file easily:
 # [PosixPath('/Users/wfondrie/.ppx/PXD000001/README.txt')]
 ```
 
+### Downloading to cloud storage backend
+
+Requires [cloudpathlib](https://cloudpathlib.drivendata.org/stable/):
+
+```
+pip install cloudpathlib[s3,gs]
+```
+
+You should create the storage bucket beforehand, to avoid bucket name conflict issues.
+If you're using GCP storage:
+
+``` Python
+>>> proj = ppx.find_project("PXD000001", local="gs://$YOUR_BUCKET")
+>>> proj.download("README.txt")
+# [GSPath('gs://$YOUR_BUCKET/PXD000001/README.txt')]
+```
+
 ## If you are an R user...
 
 ppx was inspired the rpx R package by Laurent Gatto. Check it out on

--- a/README.md
+++ b/README.md
@@ -119,11 +119,7 @@ session, we can find our previous file easily:
 
 ### Downloading to cloud storage backend
 
-Requires [cloudpathlib](https://cloudpathlib.drivendata.org/stable/):
-
-```
-pip install cloudpathlib[s3,gs]
-```
+Uses [CloudPathlib](https://cloudpathlib.drivendata.org/stable/) backend.
 
 You should create the storage bucket beforehand, to avoid bucket name conflict issues.
 If you're using GCP storage:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -23,6 +23,14 @@ Why does ppx set a default data directory? We found that this makes it easier
 to reuse the same proteomics data files in multiple tasks that we're working
 on.
 
+As of ppx v1.3.0, cloud paths can also be used as the data directory. This
+allows you to stream downloaded files to AWS S3, Google Cloud Storage, or Azure
+Blob Storage. To use a cloud storage provider, simply set the data directory to
+a cloud URI, such as :code:`s3://my-data-bucket/ppx` using any of the methods
+above. Please note that you'll also need to setup credentials for your cloud
+provider---see the `CloudPathLib documentation
+<https://cloudpathlib.drivendata.org/v0.6/authentication/>_` for details.
+
 Examples
 --------
 
@@ -68,7 +76,7 @@ repository in which the project data resides. If we start a new Python
 session, we can find our previous files easily:
 
     >>> import ppx
-    >>> proj = ppx.find_project("PXD000001", rep="PRIDE")
+    >>> proj = ppx.find_project("PXD000001", repo="PRIDE")
     >>> local_files = proj.local_files()
     >>> print(local_files)
     [PosixPath('/Users/wfondrie/.ppx/PXD000001/F063721.dat-mztab.txt')]
@@ -76,3 +84,23 @@ session, we can find our previous files easily:
 For more details about the available methods for a project, see our Python API
 documentation for the :py:class:`~ppx.PrideProject` and
 :py:class:`~ppx.MassiveProject` classes.
+
+Using Cloud Storage
++++++++++++++++++++
+
+We use `CloudPathlib <https://cloudpathlib.drivendata.org/stable/>_` to power
+support for AWS S3, Google Cloud Storage, and Azure Blob Storage. To use a
+cloud storage provider, create the bucket for ppx to use and set it as the ppx
+data directory.
+
+For example using AWS S3, we can save the files of a project to an S3 bucket:
+
+    >>> proj = ppx.find_project("PXD000001", local="s3://my-bucket/PXD000001")
+    >>> proj.download("README.txt")
+    [S3Path('s3://my-bucket/PXD000001/README.txt')]
+
+CloudPathLib then provides methods to download files from S3 when you need them:
+
+    >>> readme_on_s3 = proj.local_files("README.txt")[0]
+    >>> readme_on_s3.download_to("README.txt")
+    PosixPath(README.txt)

--- a/ppx/config.py
+++ b/ppx/config.py
@@ -40,7 +40,6 @@ class PPXConfig:
                 path = Path.home() / ".ppx"
         else:
             path = self._resolve_path(path)
-            print(path)
             if not path.exists():
                 raise FileNotFoundError(
                     f"The specified directory or bucket ({path}) "

--- a/ppx/config.py
+++ b/ppx/config.py
@@ -3,6 +3,8 @@ import os
 import logging
 from pathlib import Path
 
+from cloudpathlib import AnyPath
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -29,21 +31,45 @@ class PPXConfig:
         """Set the current ppx data directory"""
         if path is None:
             try:
-                path = Path(os.environ["PPX_DATA_DIR"]).expanduser().resolve()
+                path = self._resolve_path(os.environ["PPX_DATA_DIR"])
                 if not path.exists():
                     raise FileNotFoundError(
                         f"The specified PPX_DATA_DIR ({path}) does not exist."
                     )
             except KeyError:
-                path = Path(Path.home(), ".ppx")
+                path = Path.home() / ".ppx"
         else:
-            path = Path(path).expanduser().resolve()
+            path = self._resolve_path(path)
+            print(path)
             if not path.exists():
                 raise FileNotFoundError(
-                    f"The specified directory ({path}) does not exist."
+                    f"The specified directory or bucket ({path}) "
+                    "does not exist."
                 )
 
         self._path = path
+
+    @staticmethod
+    def _resolve_path(path):
+        """Resolve a Path or CloudPath
+
+        Parameters
+        ----------
+        path : str
+            The path to resolve.
+
+        Returns
+        -------
+        Path or CloudPath
+            The resolved path.
+        """
+        path = AnyPath(path)
+        try:
+            path = path.expanduser().resolve()
+        except AttributeError:
+            pass
+
+        return path
 
 
 def get_data_dir():

--- a/ppx/factory.py
+++ b/ppx/factory.py
@@ -21,9 +21,10 @@ class PXDFactory:
     ----------
     pxid : str
         A ProteomeXchange identifier.
-    local : str or Path object, optional
-        The local data directory in which this project's files will be
-        downloaded.
+    local : str, pathlib.Path, or cloudpathlib.CloudPath, optional
+        The local data directory in which the project files will be
+        downloaded. In addition to local paths, paths to AWS S3,
+        Google Cloud Storage, or Azure Blob Storage can be used.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
     timeout : float, optional
@@ -138,9 +139,11 @@ def find_project(identifier, local=None, repo=None, fetch=False, timeout=10.0):
     ----------
     identifier : str
         The project identifier.
-    local : str or Path-like object, optional
-        The directory where ppx will look for and download files from this
-        project. The default is :code:`~/.ppx`
+    local :  str, pathlib.Path, or cloudpathlib.CloudPath, optional
+        The local data directory in which the project files will be
+        downloaded. In addition to local paths, paths to AWS S3,
+        Google Cloud Storage, or Azure Blob Storage can be used.
+        The default is :code:`~/.ppx`
     repo : {"pride", "massive"}, optional
         The repository in which to look for the project. If :code:`None`,
         ppx will try to figure it out.

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -4,10 +4,7 @@ import re
 import socket
 from ftplib import FTP, error_temp, error_perm
 from functools import partial
-from pathlib import Path
-from typing import Union, List
 
-from cloudpathlib import CloudPath
 from tqdm.auto import tqdm
 
 from .utils import listify
@@ -217,18 +214,12 @@ class FTPParser:
 
         return files + new_files, dirs + new_dirs
 
-    def download(
-        self,
-        files: Union[str, List[str]],
-        dest_dir: Union[Path, CloudPath],
-        force_=False,
-        silent=False,
-    ):
+    def download(self, files, dest_dir, force_=False, silent=False):
         """Download the files
 
         Parameters
         ----------
-        files : [str]
+        files : list of str
             The file(s) to download.
         dest_dir : pathlib.Path or cloudpathlib.CloudPath object
             The destination directory. Can be a cloud storage bucket.

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -1,11 +1,13 @@
 """General utilities for working with the repository FTP sites."""
-import re
 import logging
+import re
 import socket
-from pathlib import Path
-from functools import partial
 from ftplib import FTP, error_temp, error_perm
+from functools import partial
+from pathlib import Path
+from typing import Union, List
 
+from cloudpathlib import CloudPath
 from tqdm.auto import tqdm
 
 from .utils import listify
@@ -205,15 +207,21 @@ class FTPParser:
 
         return files + new_files, dirs + new_dirs
 
-    def download(self, files, dest_dir, force_=False, silent=False):
+    def download(
+        self,
+        files: Union[str, List[str]],
+        dest_dir: Union[Path, CloudPath],
+        force_=False,
+        silent=False,
+    ):
         """Download the files
 
         Parameters
         ----------
-        remote_file : str
-            The file to download.
-        out_file : pathlib.Path object
-            The local file.
+        files : [str]
+            The file(s) to download.
+        dest_dir : pathlib.Path or cloudpathlib.CloudPath object
+            The destination directory. Can be a cloud storage bucket.
         force_ : bool
             Force the files to be redownloaded, even they already exist.
         silent : bool
@@ -230,7 +238,7 @@ class FTPParser:
         )
 
         for fname in overall_pbar(files):
-            out_file = Path(dest_dir, fname)
+            out_file = dest_dir / fname
             out_files.append(out_file)
             out_file.parent.mkdir(parents=True, exist_ok=True)
             self._download_file(fname, out_file, silent=silent, force_=force_)

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -146,8 +146,7 @@ class FTPParser:
             disable=silent,
         )
 
-        mode = "wb+" if force_ else "ab+"
-        with out_file.open(mode) as out:
+        with self.open_(out_file, force_) as out:
             start_pos = out.tell()
             pbar.update(start_pos)
 
@@ -165,6 +164,17 @@ class FTPParser:
             )
 
         self.quit()
+
+    @staticmethod
+    def open_(out_file, force_):
+        """
+        CloudPath does a check for file creation times, refusing to overwrite newer
+        files. force_overwrite_to_cloud is required.
+        """
+        if force_:
+            return out_file.open("wb+", force_overwrite_to_cloud=True)
+        else:
+            return out_file.open("ab+")
 
     def _transfer_file(self, fname, fhandle, pbar):
         """Perform the actual file transfer.

--- a/ppx/ftp.py
+++ b/ppx/ftp.py
@@ -5,6 +5,7 @@ import socket
 from ftplib import FTP, error_temp, error_perm
 from functools import partial
 
+from cloudpathlib import CloudPath
 from tqdm.auto import tqdm
 
 from .utils import listify
@@ -168,10 +169,11 @@ class FTPParser:
         CloudPath does a check for file creation times, refusing to overwrite newer
         files. force_overwrite_to_cloud is required.
         """
-        if force_:
-            return out_file.open("wb+", force_overwrite_to_cloud=True)
-        else:
-            return out_file.open("ab+")
+        open_kwargs = {"mode": "wb+" if force_ else "ab+"}
+        if isinstance(out_file, CloudPath):
+            open_kwargs["force_overwrite_to_cloud"] = force_
+
+        return out_file.open(**open_kwargs)
 
     def _transfer_file(self, fname, fhandle, pbar):
         """Perform the actual file transfer.

--- a/ppx/massive.py
+++ b/ppx/massive.py
@@ -22,8 +22,10 @@ class MassiveProject(BaseProject):
     ----------
     msv_id : str
         The MassIVE identifier.
-    local : str or pathlib.Path object, optional
-        The local data directory in which to download project files.
+    local : str, pathlib.Path, or cloudpathlib.CloudPath, optional
+        The local data directory in which the project files will be
+        downloaded. In addition to local paths, paths to AWS S3,
+        Google Cloud Storage, or Azure Blob Storage can be used.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
     timeout : float, optional

--- a/ppx/pride.py
+++ b/ppx/pride.py
@@ -1,13 +1,10 @@
 """A class for PRIDE datasets"""
 import re
 import json
-from pathlib import Path
 
 import requests
 
 from . import utils
-from .ftp import FTPParser
-from .config import config
 from .project import BaseProject
 
 
@@ -20,8 +17,10 @@ class PrideProject(BaseProject):
     ----------
     pride_id : str
         The PRIDE identifier.
-    local : str or pathlib.Path object, optional
-        The local data directory in which to download project files.
+    local : str, pathlib.Path, or cloudpathlib.CloudPath, optional
+        The local data directory in which the project files will be
+        downloaded. In addition to local paths, paths to AWS S3,
+        Google Cloud Storage, or Azure Blob Storage can be used.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
     timeout : float, optional

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -104,7 +104,7 @@ class BaseProject(ABC):
             if config.path == Path(Path.home(), ".ppx"):
                 config.path.mkdir(exist_ok=True)
             self._local = Path(config.path, self.id)
-        elif path.startswith("gs://") or path.startswith("s3://"):
+        elif CloudPath.is_valid_cloudpath(path):
             self._local = CloudPath(path) / self.id
         else:
             self._local = Path(path)

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -106,9 +106,10 @@ class BaseProject(ABC):
             self._local = CloudPath(path) / self.id
         except cloudpathlib.exceptions.InvalidPrefixError:
             if path is None:
-                if config.path == Path(Path.home(), ".ppx"):
+                if config.path == (Path.home() / ".ppx"):
                     config.path.mkdir(exist_ok=True)
-                self._local = Path(config.path, self.id)
+
+                self._local = config.path / self.id
             else:
                 self._local = Path(path)
 

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -1,9 +1,8 @@
 """A base dataset class"""
 from pathlib import Path
-
-import cloudpathlib.exceptions
-from cloudpathlib import CloudPath
 from abc import ABC, abstractmethod
+
+from cloudpathlib import AnyPath
 
 from . import utils
 from .config import config
@@ -17,9 +16,10 @@ class BaseProject(ABC):
     ---------
     identifier : str
         The identifier for the project in the repository
-    local : str or Path object, optional
+    local : str, pathlib.Path, or cloudpathlib.CloudPath, optional
         The local data directory in which this project's files will be
-        downloaded.
+        downloaded. In addition to local paths, paths to AWS S3,
+        Google Cloud Storage, or Azure Blob Storage can be used.
     fetch : bool, optional
         Should ppx check the remote repository for updated metadata?
     timeout : float, optional
@@ -102,16 +102,13 @@ class BaseProject(ABC):
     @local.setter
     def local(self, path):
         """Set the local data directory for this project."""
-        try:
-            self._local = CloudPath(path) / self.id
-        except cloudpathlib.exceptions.InvalidPrefixError:
-            if path is None:
-                if config.path == (Path.home() / ".ppx"):
-                    config.path.mkdir(exist_ok=True)
+        if path is None:
+            if config.path == (Path.home() / ".ppx"):
+                config.path.mkdir(exist_ok=True)
 
-                self._local = config.path / self.id
-            else:
-                self._local = Path(path)
+            self._local = config.path / self.id
+        else:
+            self._local = AnyPath(path)
 
         self._local.mkdir(exist_ok=True)
 
@@ -187,11 +184,7 @@ class BaseProject(ABC):
         list of str
             The local directories available for this project.
         """
-        if glob is None:
-            glob = "**/[!.]*"
-
-        dirs = self.local.glob(glob)
-        return sorted([d for d in dirs if d.is_dir()])
+        return [d for d in utils.glob(self.local, glob) if d.is_dir()]
 
     def local_files(self, glob=None):
         """List the local files associated with this project.
@@ -207,11 +200,7 @@ class BaseProject(ABC):
         list of str
             The local files available for this project.
         """
-        if glob is None:
-            glob = "**/[!.]*"
-
-        files = self.local.glob(glob)
-        return sorted([f for f in files if f.is_file()])
+        return [f for f in utils.glob(self.local, glob) if f.is_file()]
 
     def download(self, files, force_=False, silent=False):
         """Download files from the remote repository.

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -1,5 +1,7 @@
 """A base dataset class"""
 from pathlib import Path
+
+import cloudpathlib.exceptions
 from cloudpathlib import CloudPath
 from abc import ABC, abstractmethod
 
@@ -100,14 +102,15 @@ class BaseProject(ABC):
     @local.setter
     def local(self, path):
         """Set the local data directory for this project."""
-        if path is None:
-            if config.path == Path(Path.home(), ".ppx"):
-                config.path.mkdir(exist_ok=True)
-            self._local = Path(config.path, self.id)
-        elif CloudPath.is_valid_cloudpath(path):
+        try:
             self._local = CloudPath(path) / self.id
-        else:
-            self._local = Path(path)
+        except cloudpathlib.exceptions.InvalidPrefixError:
+            if path is None:
+                if config.path == Path(Path.home(), ".ppx"):
+                    config.path.mkdir(exist_ok=True)
+                self._local = Path(config.path, self.id)
+            else:
+                self._local = Path(path)
 
         self._local.mkdir(exist_ok=True)
 

--- a/ppx/project.py
+++ b/ppx/project.py
@@ -1,5 +1,6 @@
 """A base dataset class"""
 from pathlib import Path
+from cloudpathlib import CloudPath
 from abc import ABC, abstractmethod
 
 from . import utils
@@ -102,8 +103,9 @@ class BaseProject(ABC):
         if path is None:
             if config.path == Path(Path.home(), ".ppx"):
                 config.path.mkdir(exist_ok=True)
-
             self._local = Path(config.path, self.id)
+        elif path.startswith("gs://") or path.startswith("s3://"):
+            self._local = CloudPath(path) / self.id
         else:
             self._local = Path(path)
 

--- a/ppx/utils.py
+++ b/ppx/utils.py
@@ -1,5 +1,9 @@
 """Utility Functions"""
+from pathlib import Path
+
 import requests
+from cloudpathlib import CloudPath
+from cloudpathlib.exceptions import CloudPathNotImplementedError
 
 
 def listify(obj):
@@ -35,3 +39,22 @@ def test_url(url):
         raise requests.HTTPError(f"Unable to connect to URL: {url}")
 
     return url
+
+
+def glob(path, pattern=None):
+    """A function to glob.
+
+    Parameters
+    ----------
+    path : Path or CloudPath
+        The path to search.
+    pattern : str, optional
+        The glob pattern.
+
+    Returns
+    -------
+    list of Path or CloudPath
+        The sorted list of files.
+    """
+    pattern = "**/[!.]*" if pattern is None else pattern
+    return sorted(path.glob(pattern))

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.6
 install_requires =
     requests>=2.23.0
     tqdm>=4.60.0
-    cloudpathlib>=0.7.0
+    cloudpat, local="gs://pdc-raw"hlib[all]>=0.7.0
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.6
 install_requires =
     requests>=2.23.0
     tqdm>=4.60.0
-    cloudpathlib[all]>=0.7.0
+    cloudpathlib[all]>=0.7.1
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ python_requires = >=3.6
 install_requires =
     requests>=2.23.0
     tqdm>=4.60.0
-    cloudpat, local="gs://pdc-raw"hlib[all]>=0.7.0
+    cloudpathlib[all]>=0.7.0
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ python_requires = >=3.6
 install_requires =
     requests>=2.23.0
     tqdm>=4.60.0
+    cloudpathlib>=0.7.0
 
 [options.extras_require]
 docs =

--- a/tests/unit_tests/test_cloud.py
+++ b/tests/unit_tests/test_cloud.py
@@ -1,0 +1,53 @@
+"""Test using cloud locations"""
+from cloudpathlib import CloudPath
+import ppx
+
+from . import utils
+
+MSVID = "MSV000087408"
+
+
+def test_local_arg(cloud_bucket):
+    """Test downloading data from massive to a cloudpath"""
+    proj = ppx.MassiveProject(MSVID)
+
+    # Google Cloud
+    bucket = "s3://ppx-test-bucket/ppx"
+    proj = ppx.MassiveProject(MSVID, local=bucket)
+    assert isinstance(proj.local, CloudPath)
+    files = proj.local_files()
+    assert files == []
+
+    fname = "ccms_statistics/statistics.tsv"
+    txt = proj.download(fname)
+    orig_sig = utils.sig(txt[0])
+    files = proj.local_files()
+    local_txt = CloudPath(bucket) / fname
+    assert txt == [local_txt]
+    assert files[0] == local_txt
+
+    txt = proj.download(fname)  # should do nothing
+    assert orig_sig == utils.sig(local_txt)
+
+    txt = proj.download(fname, force_=True)
+    new_size, new_mtime = utils.sig(local_txt)
+    assert orig_sig[0] == new_size
+    assert orig_sig[1] != new_mtime
+
+
+def test_data_dir(cloud_bucket):
+    """Test that setting the ppx data directory works."""
+    bucket = "s3://ppx-test-bucket/ppx"
+    ppx.set_data_dir(bucket)
+
+    proj = ppx.MassiveProject(MSVID)
+    assert isinstance(proj.local, CloudPath)
+    files = proj.local_files()
+    assert files == []
+
+    fname = "ccms_statistics/statistics.tsv"
+    txt = proj.download(fname)
+    files = proj.local_files()
+    local_txt = CloudPath(bucket) / MSVID / fname
+    assert txt == [local_txt]
+    assert files[0] == local_txt

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import ppx
+from cloudpathlib import CloudPath
 
 PXID = "PXD000001"
 
@@ -42,3 +43,17 @@ def test_change_dir(monkeypatch, tmp_path):
 
     proj = ppx.PrideProject(PXID)
     assert proj.local == test_dir / PXID
+
+
+def test_cloud(monkeypatch, cloud_bucket):
+    """Test a cloud location"""
+    test_bucket = "s3://ppx-test-bucket/ppx"
+    ppx.set_data_dir(test_bucket)
+    assert ppx.get_data_dir() == CloudPath(test_bucket)
+
+    ppx.set_data_dir()  # reset it.
+    assert ppx.get_data_dir() != CloudPath(test_bucket)
+
+    monkeypatch.setenv("PPX_DATA_DIR", str(test_bucket))
+    ppx.set_data_dir()
+    assert ppx.get_data_dir() == CloudPath(test_bucket)

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -2,12 +2,12 @@
 
 These tests are in a separate file because they all require internet access.
 """
-import filecmp
 from ftplib import FTP, error_temp
 
 import pytest
 import ppx
-import requests
+
+from . import utils
 
 PXID = "PXD000001"
 MSVID = "MSV000087408"
@@ -38,15 +38,15 @@ def test_pride_download(tmp_path):
     txt = proj.download(fname)
     files = proj.local_files()
     local_txt = tmp_path / PXID / fname
-    orig_sig = sig(local_txt)
+    orig_sig = utils.sig(local_txt)
     assert txt == [local_txt]
     assert files[0] == local_txt
 
     txt = proj.download(fname)  # should do nothing
-    assert orig_sig == sig(local_txt)
+    assert orig_sig == utils.sig(local_txt)
 
     txt = proj.download(fname, force_=True)
-    new_size, new_mtime = sig(local_txt)
+    new_size, new_mtime = utils.sig(local_txt)
     assert orig_sig[0] == new_size
     assert orig_sig[1] != new_mtime
 
@@ -92,22 +92,17 @@ def test_massive_download(tmp_path):
     txt = proj.download(fname)
     files = proj.local_files()
     local_txt = tmp_path / MSVID / fname
-    orig_sig = sig(local_txt)
+    orig_sig = utils.sig(local_txt)
     assert txt == [local_txt]
     assert files[0] == local_txt
 
     txt = proj.download(fname)  # should do nothing
-    assert orig_sig == sig(local_txt)
+    assert orig_sig == utils.sig(local_txt)
 
     txt = proj.download(fname, force_=True)
-    new_size, new_mtime = sig(local_txt)
+    new_size, new_mtime = utils.sig(local_txt)
     assert orig_sig[0] == new_size
     assert orig_sig[1] != new_mtime
 
     proj.timeout = 10
     assert proj._parser_state is None
-
-
-def sig(f):
-    st = f.stat()
-    return st.st_size, st.st_mtime

--- a/tests/unit_tests/utils.py
+++ b/tests/unit_tests/utils.py
@@ -1,0 +1,7 @@
+"""Utility functions"""
+
+
+def sig(fname):
+    """Get the size and edit time of file."""
+    stats = fname.stat()
+    return stats.st_size, stats.st_mtime


### PR DESCRIPTION
Resolves #24 

Adds one dependency: cloudpathlib

cloudpathlib is API compatible with pathlib. Very few lines needed to be changed: refraining from calling Path directly
in ftp.py, and dispatching to either Path or CloudPath in project.py when local is received.

No tests, not sure how to test without leaking credentials. Any feedback?