### PR TITLE
Updated PRIDE URL in unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for ppx
 
+## [Unreleased]
+### Fixed
+- Updated unit tests with new PRIDE FTP URLs.
+
 ## [1.3.0] - 2022-04-39
 ### Added
 - Support for cloud provider destinations. Thanks @sooheon! 

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -214,5 +214,4 @@ def test_broken_pride_links(tmp_path, monkeypatch):
         return url
 
     monkeypatch.setattr(ppx.utils, "test_url", mock_test_url)
-    print(proj.url)
     assert proj.url == url

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import ppx
+import requests
 
 PXID = "PXD000001"
 
@@ -197,3 +198,21 @@ def test_local_files(local_files, tmp_path):
 
     res = proj.local_dirs("*0")
     assert res == [tmp_path / "test_dir0"]
+
+
+def test_broken_pride_links(tmp_path, monkeypatch):
+    """Test other types of links that PRIDE might use."""
+    proj = ppx.PrideProject(PXID)
+    url = "ftp://ftp.ebi.ac.uk/pride-archive/2012/03/PXD000001"
+    _ = proj.metadata
+
+    # Monkey patch test_url:
+    def mock_test_url(url):
+        if not "ftp.ebi.ac.uk" in url:
+            raise requests.HTTPError
+
+        return url
+
+    monkeypatch.setattr(ppx.utils, "test_url", mock_test_url)
+    print(proj.url)
+    assert proj.url == url

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -11,7 +11,7 @@ PXID = "PXD000001"
 def test_init(tmp_path):
     """Test initialization"""
     proj = ppx.PrideProject(PXID)
-    url = "ftp://ftp.pride.ebi.ac.uk/pride-archive/2012/03/PXD000001"
+    url = "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001"
     assert proj.id == PXID
     assert proj.url == url
     assert proj.url == url  # Do again to get from cache

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,0 +1,40 @@
+"""Test the utility functions"""
+import ppx
+import pytest
+import requests
+
+
+def test_listify():
+    """Test that listify works"""
+    assert ppx.utils.listify("ABC") == ["ABC"]
+    assert ppx.utils.listify(["ABC"]) == ["ABC"]
+    assert ppx.utils.listify(123) == [123]
+    assert ppx.utils.listify((1, 2)) == [1, 2]
+
+
+def test_test_url():
+    """Test the URL test function"""
+    massive = "http://www.google.com"
+    assert ppx.utils.test_url(massive) == massive
+
+    wrong = "http://willfondrie.com/blah"
+    with pytest.raises(requests.HTTPError):
+        ppx.utils.test_url(wrong)
+
+
+def test_glob(tmp_path):
+    """Test glob"""
+    files = ["a.txt", "a.csv", "b/c.txt", "d/e.csv", ".ignore"]
+    paths = []
+    for fname in files:
+        path = tmp_path / fname
+        path.parent.mkdir(exist_ok=True, parents=True)
+        path.touch()
+        paths.append(path)
+
+    dirs = [tmp_path / "b", tmp_path / "d"]
+
+    assert ppx.utils.glob(tmp_path) == sorted(paths[:-1] + dirs)
+    assert ppx.utils.glob(tmp_path, "a.*") == sorted(paths[:2])
+    assert ppx.utils.glob(tmp_path, "**/*.txt") == sorted([paths[0], paths[2]])
+    assert ppx.utils.glob(tmp_path, "**/*") == sorted(paths + dirs)


### PR DESCRIPTION
PRIDE has completed the migration of their data to a new server and it seems the URLs reverted back to their original form. This PR updates our unit tests to reflect the change.