### PR TITLE
Fix MassIVE `ccms_peak` downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.4.4]
+- Fix links to MassIVE `ccms_peak` files. See [this issue](https://github.com/CCMS-UCSD/MassIVEDocumentation/issues/30#issue) for details.
+
+## [1.4.3]
+### Fixed
+- MassIVE and PRIDE links...again
+
 ## [1.4.2]
 ### Fixed
 - Fix Test status badge.

--- a/tests/unit_tests/test_download.py
+++ b/tests/unit_tests/test_download.py
@@ -112,3 +112,16 @@ def test_massive_download(tmp_path):
 
     proj.timeout = 10
     assert proj._parser_state is None
+
+
+def test_massive_ccms_peak(tmp_path):
+    """Test a ccms_peak file."""
+    # TODO: Find a smaller file.
+    proj = ppx.MassiveProject("MSV000080544")
+    files = proj.local_files()
+    assert files == []
+
+    fname = "ccms_peak/RAW/01709a_GA9-TUM_second_pool_1_01_01-ETD-1h-R2.mzXML"
+    proj.download(fname)
+    files = proj.local_files()
+    assert len(files) > 0


### PR DESCRIPTION
Fixes the changed FTP links for the `ccms_peak` files in MassIVE. See https://github.com/CCMS-UCSD/MassIVEDocumentation/issues/30 for details.