### PR TITLE
Add support for the Pride API v3

### DIFF
--- a/ppx/project.py
+++ b/ppx/project.py
@@ -36,6 +36,7 @@ class BaseProject(ABC):
         self._url = None
         self._parser_state = None
         self._metadata = None
+        self._files_metadata = None
         self._remote_files = None
         self._remote_dirs = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,31 @@ def cloud_bucket(monkeypatch):
     LocalS3Client.reset_default_storage_dir()
 
 
-# PRIDE projects/<accession>/files endpoint -----------------------------------
+# PRIDE projects/files-path/<accession> endpoint ------------------------------
+class MockPrideFilesPathResponse:
+    """A mock of the PRIDE files path REST response"""
+
+    status_code = 200
+
+    @staticmethod
+    def json():
+        with open("tests/data/pride_files_path_response.json") as ref:
+            out = json.load(ref)
+
+        return out
+
+
+@pytest.fixture
+def mock_pride_files_path_response(monkeypatch):
+    """Patch requests.get() to use a local file."""
+
+    def mock_get(*args, **kwargs):
+        return MockPrideFilesPathResponse()
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+
+# PRIDE projects/<accession>/files/all endpoint -------------------------------
 class MockPrideFilesResponse:
     """A mock of the PRIDE files REST response"""
 
@@ -74,7 +98,7 @@ def mock_pride_files_response(monkeypatch):
     monkeypatch.setattr(requests, "get", mock_get)
 
 
-# PRIDE projects/<accession? endpoint -----------------------------------------
+# PRIDE projects/<accession> endpoint -----------------------------------------
 class MockPrideProjectResponse:
     """A mock of the PRIDE projects REST response"""
 

--- a/tests/data/pride_files_path_response.json
+++ b/tests/data/pride_files_path_response.json
@@ -1,0 +1,4 @@
+{
+  "ftp": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/generated",
+  "globus": "https://app.globus.org/file-manager?origin_id=47772002-3e5b-4fd3-b97c-18cee38d6df2&origin_path=/pride-archive/03/PXD000001/PXD000001"
+}

--- a/tests/data/pride_files_response.json
+++ b/tests/data/pride_files_response.json
@@ -31,16 +31,11 @@
     "fileSizeBytes": 497985,
     "fileName": "PRIDE_Exp_Complete_Ac_22134.pride.mztab.gz",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/5bda360133398f66021c8889e01dce921cb51300c7269e1f2b0f20368ab20af6"
-      }
-    ]
+    "totalDownloads": 524
   },
   {
     "projectAccessions": [
@@ -74,16 +69,11 @@
     "fileSizeBytes": 16448103,
     "fileName": "PRIDE_Exp_Complete_Ac_22134.pride.mgf.gz",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/ca2e3dea18950a328b7dc8303911961267a2c19058e67bfe49ab0d6784c3f62b"
-      }
-    ]
+    "totalDownloads": 524
   },
   {
     "projectAccessions": [
@@ -117,16 +107,11 @@
     "fileSizeBytes": 243031280,
     "fileName": "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.mzXML",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/8ce43227bda837e3cad6c4fa1b11c4094291c48d76ca469c66e0a4e1efebd7e7"
-      }
-    ]
+    "totalDownloads": 551
   },
   {
     "projectAccessions": [
@@ -160,16 +145,11 @@
     "fileSizeBytes": 1657668,
     "fileName": "erwinia_carotovora.fasta",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/34476b308bb9dab10edab047891e2ef5ded65f458ba5c24022cfab3e1f757e90"
-      }
-    ]
+    "totalDownloads": 2754
   },
   {
     "projectAccessions": [
@@ -203,16 +183,11 @@
     "fileSizeBytes": 220475548,
     "fileName": "TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01.raw",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/ffdea08e7981243dbf92b1cc6076edc8f481ba3e6db0d1e0ad641c8faa544b90"
-      }
-    ]
+    "totalDownloads": 524
   },
   {
     "projectAccessions": [
@@ -246,16 +221,11 @@
     "fileSizeBytes": 304798,
     "fileName": "F063721.dat-mztab.txt",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/8e9f031d8e56f5026860a1b116cbb8769787993c35f72b1d449254963c787b65"
-      }
-    ]
+    "totalDownloads": 524
   },
   {
     "projectAccessions": [
@@ -289,16 +259,11 @@
     "fileSizeBytes": 10677205,
     "fileName": "PRIDE_Exp_Complete_Ac_22134.xml.gz",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/146448a5a94636a2564a48082859cefac47c5e490fdc97b092a45c49c0a183ed"
-      }
-    ]
+    "totalDownloads": 53
   },
   {
     "projectAccessions": [
@@ -332,15 +297,10 @@
     "fileSizeBytes": 21185462,
     "fileName": "F063721.dat",
     "compress": false,
-    "submissionDate": 1331596800000,
-    "publicationDate": 1331078400000,
-    "updatedDate": 1497970626000,
+    "submissionDate": "2012-03-13T00:00:00.000+00:00",
+    "publicationDate": "2012-03-07T00:00:00.000+00:00",
+    "updatedDate": "2017-06-20T14:57:06.000+00:00",
     "additionalAttributes": [],
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/files/4b46ae91064697f1c8df768df676ffaf7c6f0dad4f29523003be62fa09e7826c"
-      }
-    ]
+    "totalDownloads": 524
   }
 ]

--- a/tests/data/pride_project_response.json
+++ b/tests/data/pride_project_response.json
@@ -1,15 +1,7 @@
 {
   "accession": "PXD000001",
   "title": "TMT spikes -  Using R and Bioconductor for proteomics data analysis",
-  "additionalAttributes": [
-    {
-      "@type": "CvParam",
-      "cvLabel": "PRIDE",
-      "accession": "PRIDE:0000411",
-      "name": "Dataset FTP location",
-      "value": "ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001"
-    }
-  ],
+  "additionalAttributes": [],
   "projectDescription": "Expected reporter ion ratios: Erwinia peptides:    1:1:1:1:1:1 Enolase spike (sp|P00924|ENO1_YEAST):  10:5:2.5:1:2.5:10 BSA spike (sp|P02769|ALBU_BOVIN):  1:2.5:5:10:5:1 PhosB spike (sp|P00489|PYGM_RABIT):  2:2:2:2:1:1 Cytochrome C spike (sp|P62894|CYC_BOVIN): 1:1:1:1:1:2",
   "sampleProcessingProtocol": "Not available",
   "dataProcessingProtocol": "Two extra files have been added post-publication:<br><a href=\"ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML\" target=\"_top\">TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzML</a><br><a href=\"ftp://ftp.pride.ebi.ac.uk/pride/data/archive/2012/03/PXD000001/TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML\" target=\"_top\">TMT_Erwinia_1uLSike_Top10HCD_isol2_45stepped_60min_01-20141210.mzXML</a>",
@@ -23,11 +15,15 @@
   ],
   "doi": "10.6019/PXD000001",
   "submissionType": "COMPLETE",
+  "license": "EBI terms of use",
   "submissionDate": "2012-03-13",
   "publicationDate": "2012-03-07",
   "submitters": [
     {
       "title": "Dr",
+      "firstName": "Laurent",
+      "lastName": "Gatto",
+      "identifier": "710175",
       "affiliation": "Department of Biochemistry, University of Cambridge",
       "email": "lg390@cam.ac.uk",
       "country": "",
@@ -36,18 +32,21 @@
       "id": "710175"
     }
   ],
-  "labPIs": [],
-  "affiliations": [
-    "Department of Biochemistry, University of Cambridge"
+  "labPIs": [
+    {
+      "title": "Dr",
+      "firstName": "Laurent",
+      "lastName": "Gatto",
+      "identifier": "3017564",
+      "affiliation": "Department of Biochemistry, University of Cambridge",
+      "email": "lg390@cam.ac.uk",
+      "country": "",
+      "orcid": "",
+      "name": "Laurent Gatto",
+      "id": "3017564"
+    }
   ],
   "instruments": [
-    {
-      "@type": "CvParam",
-      "cvLabel": "MS",
-      "accession": "MS:1000031",
-      "name": "instrument model",
-      "value": "LTQ Orbitrap Velos"
-    },
     {
       "@type": "CvParam",
       "cvLabel": "MS",
@@ -63,11 +62,35 @@
       "name": "Matrix Science Mascot 2.3.02"
     }
   ],
+  "experimentTypes": [
+    {
+      "@type": "CvParam",
+      "cvLabel": "PRIDE",
+      "accession": "PRIDE:0000428",
+      "name": "Bottom-up proteomics"
+    }
+  ],
   "quantificationMethods": [],
   "countries": [
     "United Kingdom"
   ],
-  "sampleAttributes": [],
+  "sampleAttributes": [
+    {
+      "@type": "Tuple",
+      "key": {
+        "cvLabel": "EFO",
+        "accession": "OBI:0100026",
+        "name": "organism"
+      },
+      "value": [
+        {
+          "cvLabel": "NEWT",
+          "accession": "554",
+          "name": "Erwinia carotovora"
+        }
+      ]
+    }
+  ],
   "organisms": [
     {
       "@type": "CvParam",
@@ -81,9 +104,8 @@
   "references": [
     {
       "referenceLine": "Gatto L, Christoforou A; Using R and Bioconductor for proteomics data analysis., Biochim Biophys Acta, 2013 May 18, ",
-      "doi": "10.1016/j.bbapap.2013.04.032",
-      "pubmedId": 23692960,
-      "id": 23692960
+      "pubmedID": 23692960,
+      "doi": "10.1016/j.bbapap.2013.04.032"
     }
   ],
   "identifiedPTMStrings": [
@@ -106,15 +128,5 @@
       "name": "methylthiolated residue"
     }
   ],
-  "_links": {
-    "self": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001"
-    },
-    "files": {
-      "href": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001/files"
-    },
-    "datasetFtpUrl": {
-      "href": "ftp://ftp.pride.ebi.ac.uk/pride-archive/2012/03/PXD000001"
-    }
-  }
+  "totalFileDownloads": 0
 }

--- a/tests/unit_tests/test_pride.py
+++ b/tests/unit_tests/test_pride.py
@@ -102,7 +102,9 @@ def test_metadata(mock_pride_project_response):
     assert proj.doi == "10.6019/PXD000001"
 
 
-def test_remote_files(mock_pride_project_response):
+def test_remote_files(
+    mock_pride_project_response, mock_pride_files_path_response
+):
     """Test that listing remote files works"""
     proj = ppx.PrideProject(PXID)
     files = proj.remote_files()
@@ -144,14 +146,18 @@ def test_remote_files(mock_pride_project_response):
     assert proj.remote_files("blah") == []
 
 
-def test_remote_dirs(mock_pride_project_response):
+def test_remote_dirs(
+    mock_pride_project_response, mock_pride_files_path_response
+):
     """Test that listing remote directories works"""
     proj = ppx.PrideProject(PXID)
     dirs = proj.remote_dirs()
     assert dirs == ["generated"]
 
 
-def test_cached_remote_files(tmp_path, mock_pride_project_response):
+def test_cached_remote_files(
+    tmp_path, mock_pride_project_response, mock_pride_files_path_response
+):
     """Test that caching remote files works"""
     cached = tmp_path / ".remote_files"
 
@@ -168,7 +174,9 @@ def test_cached_remote_files(tmp_path, mock_pride_project_response):
     assert files != test_files
 
 
-def test_cached_remote_dirs(tmp_path, mock_pride_project_response):
+def test_cached_remote_dirs(
+    tmp_path, mock_pride_project_response, mock_pride_files_path_response
+):
     """Test that caching remote directories works"""
     cached = tmp_path / ".remote_dirs"
 


### PR DESCRIPTION
The Pride has released a new version of the API v3 and retired the old one on Feb 1, 2025. This commit fixes the project metadata and FTP folder location fetching from the Pride.